### PR TITLE
Document architecture roles and annotate Auth flow responsibilities

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -25,3 +25,10 @@ Modules/
 - **Shared UI** belongs in `Modules/Common`, especially reusable views, modifiers, and helpers.
 - **Infrastructure and integrations** (networking stacks, SDK wrappers, persistence) belong in `Modules/Core`.
 - Avoid placing new code at the repo root; instead, create or reuse an appropriate module folder.
+
+## Roles
+
+- **ViewController**: only UI setup, binding, and rendering (no business logic).
+- **ViewModel**: state, business logic, error handling, and service calls.
+- **Coordinator**: navigation, screen creation, and flow management.
+- **Services**: networking/DB/SDK work without UIKit dependencies.

--- a/AtomLearn/Modules/Auth/Coordinator/AuthCoordinator.swift
+++ b/AtomLearn/Modules/Auth/Coordinator/AuthCoordinator.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+/// Coordinator авторизации: создаёт экран и управляет навигацией Auth flow.
 final class AuthCoordinator: AuthCoordinating {
     private weak var window: UIWindow?
 

--- a/AtomLearn/Modules/Auth/Data/FirebaseAuthRepository.swift
+++ b/AtomLearn/Modules/Auth/Data/FirebaseAuthRepository.swift
@@ -2,7 +2,7 @@ import FirebaseAuth
 import GoogleSignIn
 import UIKit
 
-// Репозиторий для авторизации через Firebase
+/// Репозиторий данных авторизации: низкоуровневые вызовы Firebase/Google SDK.
 final class FirebaseAuthRepository {
     // Вход через Google — создаёт Firebase-пользователя
     func signInWithGoogle(tokens: GoogleTokens) async throws -> AppUser {

--- a/AtomLearn/Modules/Auth/Domain/Services/AuthService.swift
+++ b/AtomLearn/Modules/Auth/Domain/Services/AuthService.swift
@@ -1,13 +1,13 @@
 import FirebaseAuth
 
-// Протокол сервиса авторизации
+/// Service API для работы с авторизацией без зависимостей на UIKit.
 protocol AuthService {
     func signInWithGoogle(tokens: GoogleTokens) async throws -> AppUser
     func signOut() async throws
     func currentUser() -> AppUser? // Геттер текущего пользователя
 }
 
-// Реализация сервиса авторизации через Firebase + Google
+/// Реализация сервиса авторизации: бизнес-логика Auth и вызовы репозитория.
 final class AuthServiceImpl: AuthService {
     private let repo: FirebaseAuthRepository
 

--- a/AtomLearn/Modules/Auth/Presentation/AuthViewController.swift
+++ b/AtomLearn/Modules/Auth/Presentation/AuthViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-// Экран авторизации через Google
+/// ViewController, отвечающий только за UI, биндинг и отображение экрана авторизации.
 final class AuthViewController: UIViewController {
     private let viewModel: AuthViewModel
     private let labelAnimator = AuthLabelAnimator()

--- a/AtomLearn/Modules/Auth/Presentation/AuthViewModel.swift
+++ b/AtomLearn/Modules/Auth/Presentation/AuthViewModel.swift
@@ -1,9 +1,11 @@
 import UIKit
 
+/// Coordinator API for Auth flow navigation.
 protocol AuthCoordinating: AnyObject {
     func showMain(for user: AppUser, animated: Bool)
 }
 
+/// ViewModel экрана авторизации: состояние, бизнес-логика, обработка ошибок и вызовы сервисов.
 final class AuthViewModel {
     private let authService: AuthService
     private let signInPresenter: GoogleSignInPresenting

--- a/AtomLearn/Modules/Auth/Presentation/UI/AuthLabelAnimator.swift
+++ b/AtomLearn/Modules/Auth/Presentation/UI/AuthLabelAnimator.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+/// UI-утилита для анимации текста на экране авторизации.
 final class AuthLabelAnimator {
     private let labels: [String]
     private let fadeInDuration: TimeInterval

--- a/AtomLearn/Modules/Auth/Presentation/UI/GoogleSignInPresenter.swift
+++ b/AtomLearn/Modules/Auth/Presentation/UI/GoogleSignInPresenter.swift
@@ -2,12 +2,13 @@ import FirebaseCore
 import GoogleSignIn
 import UIKit
 
+/// UI-протокол для запуска Google Sign-In и получения токенов.
 protocol GoogleSignInPresenting {
     @MainActor
     func signIn(from presenting: UIViewController) async throws -> GoogleTokens
 }
 
-// Провайдер входа через Google в UI-слое
+/// UI-провайдер Google Sign-In, отвечает только за показ нативного экрана.
 final class GoogleSignInPresenter: GoogleSignInPresenting {
     @MainActor
     func signIn(from presenting: UIViewController) async throws -> GoogleTokens {


### PR DESCRIPTION
### Motivation

- Clarify and document the intended responsibilities of UI, state, navigation, and service layers in the project architecture. 
- Provide an explicit, small set of role rules (`ViewController`, `ViewModel`, `Coordinator`, `Services`) to prevent responsibility leakage across layers. 
- Make the `Auth` feature a reference implementation showing how to apply these rules in practice. 
- Improve discoverability of public API responsibilities for maintainers and new contributors.

### Description

- Added a `Roles` section to `Architecture.md` documenting responsibilities for `ViewController`, `ViewModel`, `Coordinator`, and `Services`.
- Added concise doc comments (`///`) to key Auth flow classes including `AuthViewController`, `AuthViewModel`/`AuthCoordinating`, `AuthCoordinator`, `AuthService`/`AuthServiceImpl`, `FirebaseAuthRepository`, `GoogleSignInPresenter`, and `AuthLabelAnimator` to state their responsibilities.
- The changes are annotation/documentation focused and do not alter runtime logic or behavior.
- Modified files include `Architecture.md`, `AtomLearn/Modules/Auth/Presentation/AuthViewController.swift`, `AtomLearn/Modules/Auth/Presentation/AuthViewModel.swift`, `AtomLearn/Modules/Auth/Coordinator/AuthCoordinator.swift`, `AtomLearn/Modules/Auth/Domain/Services/AuthService.swift`, `AtomLearn/Modules/Auth/Data/FirebaseAuthRepository.swift`, `AtomLearn/Modules/Auth/Presentation/UI/GoogleSignInPresenter.swift`, and `AtomLearn/Modules/Auth/Presentation/UI/AuthLabelAnimator.swift`.

### Testing

- No automated tests were run for this change because it is documentation and comment-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949fafc50048327838d2acd915052de)