### PR TITLE
Add style guide and align Auth/Badges to conventions

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -32,3 +32,16 @@ Modules/
 - **ViewModel**: state, business logic, error handling, and service calls.
 - **Coordinator**: navigation, screen creation, and flow management.
 - **Services**: networking/DB/SDK work without UIKit dependencies.
+
+## Style guide
+
+- **MARK order**:
+  1. Dependencies
+  2. UI
+  3. Init
+  4. Lifecycle
+  5. Actions
+  6. Public API
+  7. Private helpers
+- **Doc-comments**: add `///` documentation for every non-`private` method/property exposed outside the type.
+- **Naming**: use plural names for list screens and match file/class names (e.g., `BadgesViewController` in `BadgesViewController.swift`).

--- a/AtomLearn/Modules/Auth/Domain/Services/AuthService.swift
+++ b/AtomLearn/Modules/Auth/Domain/Services/AuthService.swift
@@ -2,25 +2,29 @@ import FirebaseAuth
 
 /// Service API для работы с авторизацией без зависимостей на UIKit.
 protocol AuthService {
+    /// Выполняет вход через Google и возвращает пользователя.
     func signInWithGoogle(tokens: GoogleTokens) async throws -> AppUser
+    /// Выполняет выход пользователя из приложения.
     func signOut() async throws
+    /// Возвращает текущего пользователя, если он авторизован.
     func currentUser() -> AppUser? // Геттер текущего пользователя
 }
 
 /// Реализация сервиса авторизации: бизнес-логика Auth и вызовы репозитория.
 final class AuthServiceImpl: AuthService {
+    // MARK: - Dependencies
     private let repo: FirebaseAuthRepository
 
-    // Внедрение зависимостей (провайдер и репозиторий)
+    // MARK: - Init
+    /// Внедрение зависимостей (провайдер и репозиторий).
     init(
         repo: FirebaseAuthRepository = .init()
     ) {
         self.repo = repo
     }
 
-    // MARK: - Sign In
-
-    // Вход через Google (двойной шаг: Google SDK → Firebase)
+    // MARK: - AuthService
+    /// Вход через Google (двойной шаг: Google SDK → Firebase).
     func signInWithGoogle(tokens: GoogleTokens) async throws -> AppUser {
         // Авторизация через Firebase
         let user = try await repo.signInWithGoogle(tokens: tokens)
@@ -29,18 +33,14 @@ final class AuthServiceImpl: AuthService {
         return user
     }
 
-    // MARK: - Sign Out
-
-    // Выход из аккаунта
+    /// Выход из аккаунта.
     @MainActor
     func signOut() async throws {
         try await repo.signOut()  // выход из Firebase
         print("[LOG:INFO] AuthService user signed out")
     }
 
-    // MARK: - Current user (по Firebase напрямую)
-
-    // Получение текущего пользователя (если авторизован)
+    /// Получение текущего пользователя (если авторизован).
     func currentUser() -> AppUser? {
         guard let fbUser = Auth.auth().currentUser else { return nil }
         return AppUser(

--- a/AtomLearn/Modules/Auth/Presentation/AuthViewController.swift
+++ b/AtomLearn/Modules/Auth/Presentation/AuthViewController.swift
@@ -2,17 +2,20 @@ import UIKit
 
 /// ViewController, отвечающий только за UI, биндинг и отображение экрана авторизации.
 final class AuthViewController: UIViewController {
+    // MARK: - Dependencies
     private let viewModel: AuthViewModel
     private let labelAnimator = AuthLabelAnimator()
 
-    // Элементы интерфейса
+    // MARK: - UI
     private let spinner = UIActivityIndicatorView(style: .large)
     private let label = UILabel.make(text: "")
     private let stack = UIStackView()
     private let container = UIView()
     
-    let button = UIButton(type: .system) // No in stack
+    private let button = UIButton(type: .system) // No in stack
 
+    // MARK: - Init
+    /// Создаёт экран авторизации с зависимым view model.
     init(viewModel: AuthViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -20,25 +23,13 @@ final class AuthViewController: UIViewController {
     }
 
     @available(*, unavailable)
+    /// Инициализатор из storyboard недоступен.
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // Добавляем элементы в стек
-    func addToStack() {
-        [label].forEach {
-            stack.addArrangedSubview($0)
-        }
-    }
-    
-    // Отключаем автогенерацию Auto Layout (TAMIC)
-    func removeTAMIC() {
-        [container, button, stack, label, spinner].forEach {
-            $0.translatesAutoresizingMaskIntoConstraints = false
-        }
-    }
-
-    // Настройка экрана при загрузке
+    // MARK: - Lifecycle
+    /// Настройка экрана при загрузке.
     override func viewDidLoad() {
         super.viewDidLoad()
         addViews()
@@ -48,7 +39,7 @@ final class AuthViewController: UIViewController {
         view.backgroundColor = .black
     }
     
-    // Запуск анимации текста при появлении
+    /// Запуск анимации текста при появлении.
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         label.alpha = 0
@@ -56,16 +47,27 @@ final class AuthViewController: UIViewController {
         viewModel.onViewDidAppear()
     }
 
-    // MARK: - UI SETUP
-    
-    // Настройка внешнего вида кнопки, стека и меток
+    /// Остановка анимации при уходе с экрана.
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        labelAnimator.stopAnimating()
+    }
+
+    // MARK: - Actions
+    /// Обработчик нажатия на кнопку входа.
+    @objc private func handleSignInTap() {
+        viewModel.onSignInTap()
+    }
+
+    // MARK: - Private helpers
+    /// Настройка внешнего вида кнопки, стека и меток.
     private func setupUI() {
         // BUTTONS
         button.setTitle("Нажми", for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = .systemBlue
         button.layer.cornerRadius = 12
-        button.addTarget(self, action: #selector(tap), for: .touchUpInside)
+        button.addTarget(self, action: #selector(handleSignInTap), for: .touchUpInside)
         
         // STACK
         stack.axis = .vertical
@@ -122,30 +124,32 @@ final class AuthViewController: UIViewController {
             self.labelAnimator.startAnimating(label: self.label)
         }
     }
-    
-    //MARK: - TARGETS
-    
-    // Обработчик нажатия на кнопку входа
-    @objc private func tap() {
-        viewModel.onSignInTap()
+
+    /// Добавляем элементы в стек.
+    private func addToStack() {
+        [label].forEach {
+            stack.addArrangedSubview($0)
+        }
     }
-    
-    // Состояние загрузки — блокировка кнопки и спиннер
+
+    /// Отключаем автогенерацию Auto Layout (TAMIC).
+    private func removeTAMIC() {
+        [container, button, stack, label, spinner].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+    }
+
+    /// Состояние загрузки — блокировка кнопки и спиннер.
     private func setLoading(_ loading: Bool) {
         button.isEnabled = !loading
         loading ? spinner.startAnimating() : spinner.stopAnimating()
         button.alpha = loading ? 0.3 : 1.0
     }
 
-    // Отображение ошибок авторизации
+    /// Отображение ошибок авторизации.
     private func showError(_ message: String) {
         let alert = UIAlertController(title: "Ошибка входа", message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Ок", style: .default))
         present(alert, animated: true)
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        labelAnimator.stopAnimating()
     }
 }


### PR DESCRIPTION
### Motivation
- Introduce a lightweight style guide to enforce consistent `MARK` ordering, public API doc-comments, and naming conventions across modules for better readability and maintainability.
- Apply the guide to a canonical screen (`Auth`) and a representative controller (`Badges`) so the pattern can be followed on other screens.
- Ensure services expose documented public APIs without UIKit dependencies and follow the same section ordering for clarity.

### Description
- Added a `Style guide` section to `Architecture.md` specifying `MARK` order, `///` doc-comments for non-`private` APIs, and naming guidance like `BadgesViewController` in `BadgesViewController.swift`.
- Refactored `AuthViewController` to follow the guide by ordering sections (`Dependencies`, `UI`, `Init`, `Lifecycle`, `Actions`, `Private helpers`), adding doc-comments, renaming the target to `handleSignInTap`, and making UI properties `private`.
- Updated `AuthService` (protocol and `AuthServiceImpl`) with `///` comments, `MARK` sections, and an `Init` mark for injected dependencies.
- Renamed `AtomLearn/Badges/BadgeViewController.swift` to `AtomLearn/Badges/BadgesViewController.swift` and adjusted `MARK`s and doc-comments in the view controller and `BadgeGridCell` to match the style guide.

### Testing
- No automated tests were executed as part of this change.
- Local repository changes were committed successfully (code formatting and renames applied).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949fb9352348327bb0f365aa976f992)