### PR TITLE
Introduce AppCoordinator to manage Firebase Auth and root transitions

### DIFF
--- a/AtomLearn/Modules/Common/Coordinator/AppCoordinator.swift
+++ b/AtomLearn/Modules/Common/Coordinator/AppCoordinator.swift
@@ -1,0 +1,80 @@
+import FirebaseAuth
+import UIKit
+
+final class AppCoordinator {
+    private weak var window: UIWindow?
+    private let authCoordinator: AuthCoordinator
+    private var authStateDidChangeHandle: AuthStateDidChangeListenerHandle?
+    private var currentRoute: Route?
+
+    private enum Route: Equatable {
+        case auth
+        case main(userId: String)
+    }
+
+    init(window: UIWindow) {
+        self.window = window
+        self.authCoordinator = AuthCoordinator(window: window)
+    }
+
+    func start() {
+        showInitialScreen()
+        startAuthStateListener()
+    }
+
+    func stop() {
+        stopAuthStateListener()
+    }
+
+    private func showInitialScreen() {
+        if let user = Auth.auth().currentUser {
+            showMain(for: user, animated: false)
+        } else {
+            showAuth(animated: false)
+        }
+    }
+
+    private func startAuthStateListener() {
+        guard authStateDidChangeHandle == nil else { return }
+        authStateDidChangeHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            guard let self else { return }
+            if let user {
+                self.showMain(for: user, animated: true)
+            } else {
+                self.showAuth(animated: true)
+            }
+        }
+    }
+
+    private func stopAuthStateListener() {
+        guard let handle = authStateDidChangeHandle else { return }
+        Auth.auth().removeStateDidChangeListener(handle)
+        authStateDidChangeHandle = nil
+    }
+
+    private func showMain(for user: User, animated: Bool) {
+        let route = Route.main(userId: user.uid)
+        guard currentRoute != route else { return }
+        currentRoute = route
+        authCoordinator.showMain(for: makeAppUser(from: user), animated: animated)
+    }
+
+    private func showAuth(animated: Bool) {
+        guard currentRoute != .auth else { return }
+        currentRoute = .auth
+        authCoordinator.showAuth(animated: animated)
+    }
+
+    private func makeAppUser(from user: User) -> AppUser {
+        AppUser(
+            uid: user.uid,
+            name: user.displayName ?? "",
+            email: user.email,
+            displayName: user.displayName
+        )
+    }
+
+    deinit {
+        stopAuthStateListener()
+    }
+}

--- a/AtomLearn/SceneDelegate.swift
+++ b/AtomLearn/SceneDelegate.swift
@@ -1,15 +1,11 @@
 import UIKit
-import FirebaseAuth
 
 // Делегат сцены — точка входа UI
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     // Главное окно приложения
     var window: UIWindow?
-    private var authCoordinator: AuthCoordinator?
-    
-    // Handle for Firebase Auth state listener to remove it when no longer needed
-    private var authStateDidChangeHandle: AuthStateDidChangeListenerHandle?
+    private var appCoordinator: AppCoordinator?
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
@@ -18,42 +14,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let window = UIWindow(windowScene: windowScene)
         self.window = window
         window.backgroundColor = .systemBackground
-        let coordinator = AuthCoordinator(window: window)
-        self.authCoordinator = coordinator
-
-        if let fbUser = Auth.auth().currentUser {
-            // Создаём модель текущего пользователя
-            let user = AppUser(
-                uid: fbUser.uid,
-                name: fbUser.displayName ?? "",
-                email: fbUser.email,
-                displayName: fbUser.displayName
-            )
-            // Главный экран с таббаром
-            coordinator.showMain(for: user, animated: false)
-        } else {
-            // Экран авторизации
-            coordinator.showAuth(animated: false)
-        }
-
-        // Следим за сменой состояния авторизации
-        authStateDidChangeHandle = Auth.auth().addStateDidChangeListener { [weak self] _, user in
-            guard let self = self else { return }
-
-            if let user {
-                // Пользователь вошёл — переходим на главный экран
-                let appUser = AppUser(
-                    uid: user.uid,
-                    name: user.displayName ?? "",
-                    email: user.email,
-                    displayName: user.displayName
-                )
-                coordinator.showMain(for: appUser, animated: true)
-            } else {
-                // Пользователь вышел — показываем авторизацию
-                coordinator.showAuth(animated: true)
-            }
-        }
+        let coordinator = AppCoordinator(window: window)
+        self.appCoordinator = coordinator
+        coordinator.start()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
@@ -62,18 +25,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
-        if let handle = authStateDidChangeHandle {
-            Auth.auth().removeStateDidChangeListener(handle)
-            authStateDidChangeHandle = nil
-        }
-    }
-
-    deinit {
-        if let handle = authStateDidChangeHandle {
-            Auth.auth().removeStateDidChangeListener(handle)
-        }
+        appCoordinator?.stop()
     }
 
 
 }
-


### PR DESCRIPTION
### Motivation
- Centralize startup screen selection and Firebase auth state handling into a single application-level coordinator.
- Keep `SceneDelegate` minimal so it only creates the window and starts the app coordinator.
- Remove direct `FirebaseAuth` usage and `AppUser` creation from `SceneDelegate` to improve separation of concerns.
- Prevent redundant root transitions when auth state changes and the correct screen is already shown.

### Description
- Added `Modules/Common/Coordinator/AppCoordinator.swift` which encapsulates `Auth.auth().currentUser` lookup, `addStateDidChangeListener` management, conversion to `AppUser`, and navigation to Auth/Main flows. 
- `AppCoordinator` exposes `start()` and `stop()` and tracks the current route via an internal `Route` enum to avoid duplicate root transitions. 
- Updated `SceneDelegate` to remove `FirebaseAuth` usage and instead create and run `AppCoordinator` with `coordinator.start()` and call `coordinator.stop()` on disconnect. 
- Reused existing `AuthCoordinator` for showing Auth/Main screens and kept `AppUser` mapping inside `AppCoordinator`.

### Testing
- No automated tests were executed as part of this change. 
- Build and compile checks were not run by the PR tooling in this rollout. 
- Manual runtime verification is recommended to ensure `addStateDidChangeListener` behavior and root transitions are correct. 
- Existing unit/UI test suites (if any) were not invoked by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a021bbc8c832784f4aa52820fb7f7)