### PR TITLE
Document auth repository stubs and standardize TODOs

### DIFF
--- a/AtomLearn/Modules/Auth/Data/AuthRepositoryFactory.swift
+++ b/AtomLearn/Modules/Auth/Data/AuthRepositoryFactory.swift
@@ -22,24 +22,24 @@ struct AuthRepositoryFactory: ServiceProtocol {
     }
 }
 
-/// Заготовка репозитория под Supabase.
+/// Заготовка репозитория под Supabase (stub).
 final class SupabaseAuthRepository: AuthRepositoryProtocol {
     func signInWithGoogle(tokens: GoogleTokens) async throws -> AppUser {
         throw AuthError.unknown
     }
 
     func signOut() async throws {
-        // TODO: реализовать выход через Supabase.
+        // TODO(Auth): реализовать выход через Supabase.
     }
 }
 
-/// Заготовка локального репозитория (например, для офлайн/моков).
+/// Заготовка локального репозитория (stub, например, для офлайн/моков).
 final class LocalAuthRepository: AuthRepositoryProtocol {
     func signInWithGoogle(tokens: GoogleTokens) async throws -> AppUser {
         throw AuthError.unknown
     }
 
     func signOut() async throws {
-        // TODO: реализовать локальный выход.
+        // TODO(Auth): реализовать локальный выход.
     }
 }


### PR DESCRIPTION
### Motivation
- Clarify that some auth repository implementations are placeholders (stubs) so readers know they are not production-ready.
- Standardize the TODO comment format to follow the Style Guide and make ownership clearer.

### Description
- Marked `SupabaseAuthRepository` as a stub by adding a doc comment in `Modules/Auth/Data/AuthRepositoryFactory.swift`.
- Marked `LocalAuthRepository` as a stub by adding a doc comment in `Modules/Auth/Data/AuthRepositoryFactory.swift`.
- Replaced generic `// TODO:` comments with the standardized `// TODO(Auth):` format for the sign-out methods.
- No files were moved; changes were limited to `AuthRepositoryFactory.swift` and touched the two repository class comments and TODO lines.

### Testing
- No automated tests were run for this change.
- Repository build or unit test commands were not executed as part of this update.
- Git status and commit were performed to record the change.
- Manual review of the modified file was done to verify formatting and comment content.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a08de687883279a7c80a74853baca)