### PR TITLE
Refactor Home data flow: HomeService protocol, Supabase HomeRepository, ViewModel state & VC bindings

### DIFF
--- a/AtomLearn/Modules/Home/Data/HomeRepository.swift
+++ b/AtomLearn/Modules/Home/Data/HomeRepository.swift
@@ -1,8 +1,51 @@
 import Foundation
+import Supabase
 
-/// Заглушка репозитория для домашнего экрана.
+/// Репозиторий домашнего экрана.
 final class HomeRepository: HomeService {
+    // MARK: - Dependencies
+    private let client: SupabaseClient
+    private let bucket: String
+    private let badgesPath: String
+
     // MARK: - Init
     /// Создаёт репозиторий домашнего экрана.
-    init() {}
+    init(
+        client: SupabaseClient = SupabaseClient(
+            supabaseURL: SupabaseConfig.url,
+            supabaseKey: SupabaseConfig.anonKey
+        ),
+        bucket: String = SupabaseConfig.bucket,
+        badgesPath: String = "badges/badge_icons"
+    ) {
+        self.client = client
+        self.bucket = bucket
+        self.badgesPath = badgesPath
+    }
+
+    // MARK: - HomeService
+    func fetchBadgeList() async throws -> [HomeBadgeFile] {
+        let storage = client.storage.from(bucket)
+        let files = try await storage.list(path: badgesPath, options: .init(limit: 1000))
+        let sorted = files.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+
+        var results: [HomeBadgeFile] = []
+        results.reserveCapacity(sorted.count)
+
+        for file in sorted {
+            let fullPath = "\(badgesPath)/\(file.name)"
+            let url = (try? storage.getPublicURL(path: fullPath))
+            ?? try await storage.createSignedURL(path: fullPath, expiresIn: 600)
+            results.append(HomeBadgeFile(name: file.name, url: url))
+        }
+
+        return results
+    }
+
+    func loadImage(url: URL) async throws -> Data {
+        let (data, _) = try await URLSession.shared.data(from: url)
+        return data
+    }
 }

--- a/AtomLearn/Modules/Home/Domain/Services/HomeService.swift
+++ b/AtomLearn/Modules/Home/Domain/Services/HomeService.swift
@@ -1,4 +1,17 @@
 import Foundation
 
+/// Модель файла бейджа для домашнего экрана.
+struct HomeBadgeFile: Equatable {
+    /// Имя файла.
+    let name: String
+    /// URL файла в хранилище.
+    let url: URL
+}
+
 /// Протокол сервиса для домашнего экрана.
-protocol HomeService {}
+protocol HomeService {
+    /// Возвращает список файлов бейджей.
+    func fetchBadgeList() async throws -> [HomeBadgeFile]
+    /// Загружает изображение по URL.
+    func loadImage(url: URL) async throws -> Data
+}

--- a/AtomLearn/Modules/Home/Presentation/HomeViewController.swift
+++ b/AtomLearn/Modules/Home/Presentation/HomeViewController.swift
@@ -1,6 +1,4 @@
-// Домашний экран: тест интеграции Supabase
 import UIKit
-import Supabase
 
 final class HomeViewController: UIViewController {
     // MARK: - Dependencies
@@ -32,8 +30,8 @@ final class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
-        viewModel.onViewDidLoad()
-        testSupabase()
+        bindViewModel()
+        viewModel.load()
     }
 
     // MARK: - UI
@@ -45,7 +43,7 @@ final class HomeViewController: UIViewController {
         imageView.layer.cornerRadius = 12
         imageView.clipsToBounds = true
 
-        status.text = "Тест Supabase…"
+        status.text = "Загрузка…"
         status.numberOfLines = 0
         status.textAlignment = .center
 
@@ -64,103 +62,22 @@ final class HomeViewController: UIViewController {
         ])
     }
 
-    // MARK: - Networking
-    // Тест: листинг папки и загрузка первого файла
-    private func testSupabase() {
-        let client = SupabaseClient(
-            supabaseURL: SupabaseConfig.url,
-            supabaseKey: SupabaseConfig.anonKey
-        )
-        let bucket = SupabaseConfig.bucket
-        let folder = "badges/badge_icons" // Папка в бакете (без завершающего /)
-
-        Task { @MainActor in
-            // 1) Листинг папки и показ первого файла
-            do {
-                let files = try await client.storage
-                    .from(bucket)
-                    .list(path: folder, options: .init(limit: 1000))
-
-                // отсортируем по имени и возьмём первый
-                for f in files  {
-                    print(f.name)
-                }
-                print("Done")
-                let sorted = files.sorted {
-                    $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-                }
-
-                if let first = sorted.first {
-                    let firstPath = "\(folder)/\(first.name)"   // собрали полный путь
-                    // публичный или подписанный URL
-                    if let publicURL = try? client.storage.from(bucket).getPublicURL(path: firstPath) {
-                        await self.downloadAndShow(from: publicURL, labelPrefix: "first-from-list")
-                    } else {
-                        let signedURL = try await client.storage
-                            .from(bucket)
-                            .createSignedURL(path: firstPath, expiresIn: 600)
-                        await self.downloadAndShow(from: signedURL, labelPrefix: "first-from-list-signed")
-                    }
-                } else {
-                    status.text = "В папке нет файлов"
-                }
-
-                // если нужен список всех URL (необязательно для UI)
-                var results: [(name: String, url: URL)] = []
-                for f in files {
-                    let fullPath = "\(folder)/\(f.name)"
-                    if let u = try? client.storage.from(bucket).getPublicURL(path: fullPath) {
-                        results.append((f.name, u))
-                    } else {
-                        let u = try await client.storage.from(bucket).createSignedURL(path: fullPath, expiresIn: 600)
-                        results.append((f.name, u))
-                    }
-                }
-                print("[LOG:INFO] Найдено файлов: \(results.count)")
-                results.forEach { print("- \($0.name) → \($0.url)") }
-                status.text = (status.text ?? "") + "\nФайлов: \(results.count)"
-            } catch {
-                print("[LOG:ERROR] LIST error: \(error.localizedDescription)")
-                status.text = "LIST error: \(error.localizedDescription)"
-            }
-
-            // 2) (опционально) Тест фиксированного файла knownPath
-            let knownPath = SupabaseConfig.knownPath
-            do {
-                let publicURL = try client.storage.from(bucket).getPublicURL(path: knownPath)
-                await self.downloadAndShow(from: publicURL, labelPrefix: "public")
-            } catch {
-                // если бакет приватный — подпишем
-                do {
-                    let signedURL = try await client.storage
-                        .from(bucket)
-                        .createSignedURL(path: knownPath, expiresIn: 600)
-                    await self.downloadAndShow(from: signedURL, labelPrefix: "signed")
-                } catch {
-                    print("[LOG:WARN] knownPath error: \(error.localizedDescription)")
-                    status.text = (status.text ?? "") + "\nknownPath error: \(error.localizedDescription)"
-                }
+    // MARK: - Bindings
+    private func bindViewModel() {
+        viewModel.onStateChange = { [weak self] state in
+            guard let self else { return }
+            status.text = state.statusText
+            if let data = state.imageData {
+                imageView.image = UIImage(data: data)
+            } else {
+                imageView.image = nil
             }
         }
-    }
 
-    // Загрузка картинки и показ в imageView
-    private func downloadAndShow(from url: URL, labelPrefix: String) async {
-        do {
-            let (data, resp) = try await URLSession.shared.data(from: url)
-            if let http = resp as? HTTPURLResponse {
-                print("\(labelPrefix) GET status:", http.statusCode)
-            }
-            guard let img = UIImage(data: data) else {
-                status.text = (status.text ?? "") + "\n\(labelPrefix): не картинка"
-                return
-            }
-            imageView.image = img
-            status.text = (status.text ?? "") + "\n\(labelPrefix): ок (\(url.lastPathComponent))"
-            print("[LOG:INFO] \(labelPrefix) image loaded: \(url.lastPathComponent)")
-        } catch {
-            print("[LOG:ERROR] \(labelPrefix) download error: \(error.localizedDescription)")
-            status.text = (status.text ?? "") + "\n\(labelPrefix) download error: \(error.localizedDescription)"
+        viewModel.onError = { [weak self] error in
+            guard let self else { return }
+            status.text = "Ошибка: \(error.localizedDescription)"
+            imageView.image = nil
         }
     }
 }

--- a/AtomLearn/Modules/Home/Presentation/HomeViewModel.swift
+++ b/AtomLearn/Modules/Home/Presentation/HomeViewModel.swift
@@ -1,9 +1,23 @@
 import Foundation
 
+/// Состояние домашнего экрана.
+struct HomeViewState: Equatable {
+    /// Текст статуса.
+    let statusText: String
+    /// Данные изображения.
+    let imageData: Data?
+}
+
 /// ViewModel для домашнего экрана.
 final class HomeViewModel {
     // MARK: - Dependencies
     private let service: HomeService
+
+    // MARK: - Public API
+    /// Коллбэк для обновления состояния.
+    var onStateChange: ((HomeViewState) -> Void)?
+    /// Коллбэк для ошибок.
+    var onError: ((Error) -> Void)?
 
     // MARK: - Init
     /// Создаёт ViewModel домашнего экрана.
@@ -12,8 +26,37 @@ final class HomeViewModel {
     }
 
     // MARK: - Lifecycle
-    /// Обрабатывает событие загрузки экрана.
-    func onViewDidLoad() {
-        _ = service
+    /// Запускает загрузку данных домашнего экрана.
+    func load() {
+        Task { await loadContent() }
+    }
+
+    // MARK: - Private helpers
+    private func loadContent() async {
+        await publish(state: HomeViewState(statusText: "Загрузка...", imageData: nil))
+
+        do {
+            let files = try await service.fetchBadgeList()
+            guard let first = files.first else {
+                await publish(state: HomeViewState(statusText: "В папке нет файлов", imageData: nil))
+                return
+            }
+
+            let data = try await service.loadImage(url: first.url)
+            let status = "Файлов: \(files.count)\nПервый файл: \(first.name)"
+            await publish(state: HomeViewState(statusText: status, imageData: data))
+        } catch {
+            await publish(error: error)
+        }
+    }
+
+    @MainActor
+    private func publish(state: HomeViewState) {
+        onStateChange?(state)
+    }
+
+    @MainActor
+    private func publish(error: Error) {
+        onError?(error)
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a clean abstractions layer for the Home screen so storage listing and image downloading are encapsulated behind a service API.
- Move Supabase and networking logic out of the view controller to improve testability and separation of concerns.
- Expose a simple, documented public API from the ViewModel to drive UI updates via bindings.

### Description
- Added `HomeBadgeFile` model and expanded `HomeService` with `fetchBadgeList()` and `loadImage(url:)` APIs in `Modules/Home/Domain/Services/HomeService.swift`.
- Implemented `HomeRepository` that encapsulates `SupabaseClient` usage and `URLSession` image fetching in `Modules/Home/Data/HomeRepository.swift` (uses `SupabaseConfig` defaults and signs URLs when necessary).
- Introduced `HomeViewState`, `onStateChange` and `onError` callbacks and a public, documented `load()` method on `HomeViewModel` to fetch the badge list and the first image in `Modules/Home/Presentation/HomeViewModel.swift`.
- Removed inline Supabase/networking code from `HomeViewController`, added `bindViewModel()` and updated the controller to subscribe to ViewModel state/errors and update UI only from bindings in `Modules/Home/Presentation/HomeViewController.swift`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697071f4d39c832781c5d7fdf922276e)