### PR TITLE
Require explicit HomeViewModel injection for HomeViewController and assemble in HomeCoordinator

### DIFF
--- a/AtomLearn/Modules/Home/Coordinator/HomeCoordinator.swift
+++ b/AtomLearn/Modules/Home/Coordinator/HomeCoordinator.swift
@@ -14,7 +14,9 @@ final class HomeCoordinator {
     // MARK: - Public API
     /// Запускает домашний экран.
     func start() {
-        let viewController = HomeViewController()
+        let service = HomeRepository()
+        let viewModel = HomeViewModel(service: service)
+        let viewController = HomeViewController(viewModel: viewModel)
         navigationController.pushViewController(viewController, animated: true)
     }
 }

--- a/AtomLearn/Modules/Home/Presentation/HomeViewController.swift
+++ b/AtomLearn/Modules/Home/Presentation/HomeViewController.swift
@@ -13,7 +13,7 @@ final class HomeViewController: UIViewController {
 
     // MARK: - Init
     /// Создаёт домашний экран.
-    init(viewModel: HomeViewModel = HomeViewModel(service: HomeRepository())) {
+    init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }


### PR DESCRIPTION
### Motivation
- Make dependency injection explicit by removing the default `HomeViewModel` construction from `HomeViewController` and moving dependency assembly into the coordinator.

### Description
- Replaced `init(viewModel: HomeViewModel = HomeViewModel(service: HomeRepository()))` with `init(viewModel: HomeViewModel)` in `AtomLearn/Modules/Home/Presentation/HomeViewController.swift` and updated `AtomLearn/Modules/Home/Coordinator/HomeCoordinator.swift` to create `HomeRepository`, instantiate `HomeViewModel(service:)`, and pass it into `HomeViewController(viewModel:)`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69707eea81848327a9db3d17e1ed7b5d)